### PR TITLE
docker image: use ubuntu noble and jellyfin ffmpeg for qsv support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,15 +51,17 @@ RUN apt-get update && \
     curl \
     gnupg \
     ca-certificates \
-    mesa-va-drivers \
-    vainfo && \
+    mesa-va-drivers && \
     curl -s https://repo.jellyfin.org/ubuntu/jellyfin_team.gpg.key | gpg --dearmor | tee /usr/share/keyrings/jellyfin.gpg >/dev/null && \
     echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/jellyfin.gpg] https://repo.jellyfin.org/ubuntu noble main' > /etc/apt/sources.list.d/jellyfin.list && \
     curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
     apt-get install -y --no-install-recommends \
     jellyfin-ffmpeg7 \
     nodejs && \
+    # Symlink Jellyfin's ffmpeg, ffprobe and vainfo for systemwide use
     ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/bin/ffmpeg && \
+    ln -s /usr/lib/jellyfin-ffmpeg/ffprobe /usr/bin/ffprobe && \
+    ln -s /usr/lib/jellyfin-ffmpeg/vainfo /usr/bin/vainfo && \
     # Clean up apt caches to reduce final image size
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Cuda image is not necessary as CUDA bits necessary for hw transcode are injected into the container by nvidia container toolkit.

This PR does the following:
- Uses Ubuntu Noble instead, ~~and the image size is slightly smaller~~ (I lied, `mesa-va-drivers` made it just a bit bigger).
- Adds jellyfin's ffmpeg as it's purpose built for hw transcoding and comes with all necessary dependencies and libs, including some that do not have packages in the Ubuntu repo. For instance, while Ubuntu's repo version of ffmpeg has support for QSV, Ubuntu does not provide a package for intel-gpu-rt, a dependency library, and needs to be compiled. Jellyfin's ffmpeg includes that dependency.
- Adds the dependency package `mesa-va-drivers`, which is necessary for vaapi.
- Uses vainfo from jellyfin's ffmpeg package, which is currently the latest version and is newer than the ubuntu repo version

With this PR, Nvidia and Intel QSV transcode should work out of the box.
Vaapi has a separate bug where the preset ffmpeg command arguments need to be changed from the current default `-hwaccel vaapi -hwaccel_output_format vaapi -i "{streamUrl}" -vf 'format=nv12,hwupload' -c:v h264_vaapi -preset medium -c:a aac -b:a 128k -f mpegts pipe:1` to `-hwaccel vaapi -hwaccel_output_format vaapi -i "{streamUrl}" -vf "format=nv12|vaapi,hwupload" -c:v h264_vaapi -preset medium -c:a aac -b:a 128k -f mpegts pipe:1` (addition of `|vaapi` to the filter as well as changing single quotes to double quotes). #42 is opened to fix that issue.