### PR TITLE
Fix Bandwidth units to match what mpegts.js provides and add Dropped

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1295,6 +1295,8 @@
                     <p id="stream-info-fps"></p>
                     <p id="stream-info-dropped"></p>
                     <p id="stream-info-buffer"></p>
+                    <p id="stream-info-video"></p>
+                    <p id="stream-info-audio"></p>
                 </div>
                 <div id="cast-status" class="hidden absolute inset-0 flex-col items-center justify-center bg-black text-white p-4">
                     <span data-icon="cast" class="w-16 h-16 mb-4"></span>
@@ -1319,6 +1321,7 @@
     
             <div id="program-details-header" class="pb-3 border-b border-gray-700 mb-3 flex-shrink-0">
                 <div class="pr-20">
+                    <h2 id="details-channel" class="text-2xl font-bold text-white"></h2>
                     <h3 id="details-title" class="text-xl font-bold text-white"></h3>
                     <p id="details-time" class="text-sm text-gray-400"></p>
                 </div>

--- a/public/js/modules/player.js
+++ b/public/js/modules/player.js
@@ -155,15 +155,20 @@ function updateStreamInfo() {
 
     const resolution = (video.videoWidth && video.videoHeight) ? `${video.videoWidth}x${video.videoHeight}` : 'N/A';
     const speed = `${(stats.speed / 1024).toFixed(2)} MB/s`;
-    const fps = (stats.decodedFrames > 0 && typeof stats.fps === 'number') ? stats.fps.toFixed(2) : '0.00';
     const dropped = (stats.droppedFrames >= 0 && typeof stats.droppedFrames === 'number') ? stats.droppedFrames : 'N/A'
     const buffer = video.buffered.length > 0 ? `${(video.buffered.end(0) - video.currentTime).toFixed(2)}s` : '0.00s';
+    const mediaInfo = appState.player.mediaInfo;
+    const fps = mediaInfo.fps;
+    const videoCodec = mediaInfo.videoCodec;
+    const audioCodec = mediaInfo.audioCodec;
 
     UIElements.streamInfoResolution.textContent = `Resolution: ${resolution}`;
     UIElements.streamInfoBandwidth.textContent = `Bandwidth: ${speed}`;
     UIElements.streamInfoFps.textContent = `FPS: ${fps}`;
     UIElements.streamInfoDropped.textContent = `Dropped: ${dropped}`;
     UIElements.streamInfoBuffer.textContent = `Buffer: ${buffer}`;
+    UIElements.streamInfoVideo.textContent = `V Codec: ${videoCodec}`;
+    UIElements.streamInfoAudio.textContent = `A Codec: ${audioCodec}`;
 }
 
 


### PR DESCRIPTION
mpegts.js returns speed in KB/s so when we divide by 1024 we get MB/s.  So change the units from KB/s to MB/s to be correct.

Also in the player's stream info overlay:

- Added a Dropped stat as it's nice to see what's going on with that.
- Changed fps to be taken from mpegts mediaInfo which seems to work better.
- Display video and audio codec info.