### PR TITLE
Call ffmpeg with -v level+warning to manage log spamming

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,9 @@
+# Environment variables for ViniPlay
+# This file should be kept secure and not be committed to version control.
+# A long, random, and secret string used to sign the session ID cookie.
+# You can generate a good one here: https://www.random.org/strings/
+SESSION_SECRET=replace_this_with_a_very_long_random_and_secret_string
+
+# Add a contact email for VAPID push notifications.
+# This is required by push services. It should start with "mailto:".
+VAPID_CONTACT_EMAIL=mailto:your_email@example.com


### PR DESCRIPTION
viniplay currently logs everything that ffmpeg sends to stderr.  Since ffmpeg sends all logging to stderr this can result in log spamming.  By telling ffmpeg what loglevel to use we can limit this spamming to only useful messages.  We do this by prefixing ffmpeg calls with `-v level+{loglevel}` where loglevel can be debug, verbose, info (default), warning and error.

Prefixing with `-v level+warning` means we will only see ffmpeg warnings and errors in the viniplay logs.  Currently we also see info messages which can quickly fill the log.  This could also be done via the Setting page, allowing the user to select ffmpeg's loglevel.  That might be more useful, especially for debugging purposes.

The level flag tells ffmpeg to prefix messages with a tag showing what level each message actually is.  That let's us differentiate by message importance, \[error\] being more serious than \[warning\].