### PR TITLE
Allow regex's for source group selection filter

### DIFF
--- a/public/js/modules/settings.js
+++ b/public/js/modules/settings.js
@@ -1109,7 +1109,8 @@ export function setupSettingsEventListeners() {
         const lowerCaseSearch = searchTerm.toLowerCase();
         // Keep track of originally selected groups case-insensitively for checking
         const lowerCaseSelected = new Set(selectedGroups.map(g => g.toLowerCase()));
-        const filteredGroups = groupsForType.filter(g => g.toLowerCase().includes(lowerCaseSearch));
+        const re = new RegExp(searchTerm, 'g');
+        const filteredGroups = groupsForType.filter(g => g.match(re));
         const currentSelectedSet = new Set(selectedGroups);
 
         if (filteredGroups.length === 0) {


### PR DESCRIPTION
When adding sources via the settings page there is the option to filter the groups you are interested in rather than using all the available groups via the Select Groups gui.  This commit allows the use of regex's to filter the groups you want.  For example if all your english groups start with one of these prefixes: AU, CA, NZ, US, or UK you could use the following regex to filter them out to be selected: ^(AU|CA|NZ|US|UK).