### PR TITLE
Allow user to set ffmpeg log levels for ffmpeg player and dvr via settings pulldowns

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1334,7 +1334,37 @@
                             </div>
                         </div>
                     </div>
-                    
+ 
+                    <div class="bg-gray-800 p-4 sm:p-6 rounded-xl shadow-lg">
+                        <h2 class="text-xl font-bold text-white mb-4 border-b border-gray-700 pb-2">FFmpeg Logging Settings</h2>
+                        
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-8">
+                            <div>
+                                <label for="player-log-level-select" class="block text-sm font-medium text-gray-400 mb-2">Player FFmpeg Logging Level</label>
+                                <p class="text-xs text-gray-500 mb-2">Tell player what ffmpeg messages should be logged. Typically not changed unless debugging.</p>
+                                <select id="player-log-level-select" class="w-full bg-gray-700 border border-gray-600 rounded-md px-3 py-2 text-white focus:ring-blue-500 focus:border-blue-500 mb-2">
+                                    <option value="error">[error] Log all errors including handled ones</option>
+                                    <option value="warning" selected>[warning] Log all warnings and errors</option>
+                                    <option value="info">[info] Log info messages, warnings and errors</option>
+                                    <option value="verbose">[verbose] Log more info messages, warnings and errors</option>
+                                    <option value="debug">[debug] Log absolutely everything including debug messages</option>
+
+                                </select>
+                            </div>
+                            <div>
+                                <label for="dvr-log-level-select" class="block text-sm font-medium text-gray-400 mb-2">DVR FFmpeg Logging Level</label>
+                                <p class="text-xs text-gray-500 mb-2">Tell DVR what ffmpeg messages should be logged. Typically not changed  unless debugging.</p>
+                                <select id="dvr-log-level-select" class="w-full bg-gray-700 border border-gray-600 rounded-md px-3 py-2 text-white focus:ring-blue-500 focus:border-blue-500 mb-2">
+                                    <option value="error">[error] Log all errors including handled ones</option>
+                                    <option value="warning" selected>[warning] Log all warnings and errors</option>
+                                    <option value="info">[info] Log info messages, warnings and errors</option>
+                                    <option value="verbose">[verbose] Log more info messages, warnings and errors</option>
+                                    <option value="debug">[debug] Log absolutely everything including debug messages</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+  
                     <div class="bg-gray-800 p-4 sm:p-6 rounded-xl shadow-lg">
                         <h2 class="text-xl font-bold text-white mb-4 border-b border-gray-700 pb-2">Storage Management</h2>
                         <div class="space-y-4">

--- a/public/js/modules/settings.js
+++ b/public/js/modules/settings.js
@@ -327,6 +327,8 @@ export const updateUIFromSettings = async () => {
     }
     
     settings.searchScope = settings.searchScope || 'all_channels_unfiltered';
+    settings.playerLogLevel = settings.playerLogLevel || 'warning';
+    settings.dvrLogLevel = settings.dvrLogLevel || 'warning';
     settings.notificationLeadTime = settings.notificationLeadTime ?? 10;
     
     settings.dvr = settings.dvr || {};
@@ -339,6 +341,8 @@ export const updateUIFromSettings = async () => {
     UIElements.timezoneOffsetSelect.value = settings.timezoneOffset;
     fetchAndDisplayPublicIp();
     UIElements.searchScopeSelect.value = settings.searchScope;
+    UIElements.playerLogLevelSelect.value = settings.playerLogLevel;
+    UIElements.dvrLogLevelSelect.value = settings.dvrLogLevel;
     UIElements.notificationLeadTimeInput.value = settings.notificationLeadTime;
     
     // Update DVR inputs
@@ -800,6 +804,8 @@ export function setupSettingsEventListeners() {
     // --- General Settings Inputs ---
     UIElements.timezoneOffsetSelect.addEventListener('change', (e) => saveSettingAndNotify(saveGlobalSetting, { timezoneOffset: parseInt(e.target.value, 10) }));
     UIElements.searchScopeSelect.addEventListener('change', (e) => saveSettingAndNotify(saveGlobalSetting, { searchScope: e.target.value }));
+    UIElements.playerLogLevelSelect.addEventListener('change', (e) => saveSettingAndNotify(saveGlobalSetting, { playerLogLevel: e.target.value }));
+    UIElements.dvrLogLevelSelect.addEventListener('change', (e) => saveSettingAndNotify(saveGlobalSetting, { dvrLogLevel: e.target.value }));
     UIElements.notificationLeadTimeInput.addEventListener('change', async (e) => {
         const value = parseInt(e.target.value, 10);
         if (isNaN(value) || value < 1) {

--- a/server.js
+++ b/server.js
@@ -680,6 +680,8 @@ function getSettings() {
         },
         activeUserAgentId: `default-ua-1724778434000`,
         activeStreamProfileId: 'ffmpeg-default',
+        playerLogLevel: 'warning',
+        dvrLogLevel: 'warning',
         searchScope: 'all_channels_unfiltered',
         notificationLeadTime: 10,
         sourcesLastUpdated: null
@@ -2808,7 +2810,10 @@ app.get('/stream', requireAuth, async (req, res) => {
     
     console.log(`[STREAM] Using Profile='${profile.name}' (ID=${profile.id}), UserAgent='${userAgent.name}'`);
 
-    const commandTemplate = profile.command
+    // Prefix ffmpeg command with "-v level+{playerLoglevel}" here to control log spamming.
+    // Using warning loglevel limits messages to actual warnings and errors.
+    // playerLogLevel is configured via settings page pulldown.
+    const commandTemplate = `-v level+${settings.playerLogLevel} ` + profile.command
         .replace(/{streamUrl}/g, streamUrl)
         .replace(/{userAgent}|{clientUserAgent}/g, userAgent.value);
         
@@ -3465,7 +3470,9 @@ async function startRecording(job) {
     const safeFilename = `${job.id}_${job.programTitle.replace(/[^a-z0-9]/gi, '_').toLowerCase()}${fileExtension}`;
     const fullFilePath = path.join(DVR_DIR, safeFilename);
 
-    const commandTemplate = recProfile.command
+    // Prefix ffmpeg command with "-v level+{dvrLoglevel}" here to control log spamming.
+    // dvrLogLevel is configured via a settings page pulldown.
+    const commandTemplate = `-v level+${settings.dvrLogLevel} ` + recProfile.command
         .replace(/{streamUrl}/g, streamUrlToRecord)
         .replace(/{userAgent}/g, userAgent.value)
         .replace(/{filePath}/g, fullFilePath);


### PR DESCRIPTION
viniplay currently logs everything that ffmpeg sends to stderr.  Since ffmpeg sends all logging to stderr this can result in log spamming.  By telling ffmpeg what loglevel to use we can limit this spamming to only useful messages.  We do this by prefixing ffmpeg calls with `-v level+{loglevel}` where loglevel can be debug, verbose, info (default), warning and error.

Prefixing ffmpeg profiles with `-v level+warning` means we will only see ffmpeg warnings and errors in the viniplay logs.  Currently it is not set so ffmpeg defautls to info.  So we also see ffmpeg info messages which can quickly fill the log.  This PR sets the default ffmpeg log levels to warning and allows the user to change to more verbose levels for debugging/information via pulldown menus on the settings page.

The level flag also tells ffmpeg to prefix messages with a tag showing what level each message actually is.  That let's us differentiate ffmpeg logs by importance, \[error\] being more serious than \[warning\] etc.

This PR replaces #56.