### PR TITLE
Fix: use image proxy for external logos in admin and guide modules to prevent mixed content issues on HTTPS deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# Dependencies
+node_modules/
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+
+# Runtime data
+pids/
+*.pid
+*.seed
+*.pid.lock
+
+# Build outputs
+dist/
+build/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Database
+*.db
+*.sqlite
+*.sqlite3
+
+# Temporary files
+tmp/
+temp/
+
+# App data directories (local dev)
+data/
+dvr/

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ ARG TARGETARCH
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 ENV DEBIAN_FRONTEND=noninteractive
 ENV LD_LIBRARY_PATH=/usr/lib/jellyfin-ffmpeg/lib
+ENV DATA_DIR=/data
+ENV DVR_DIR=/dvr
 
 # Install only the necessary runtime dependencies: Node.js, FFmpeg, and drivers.
 # We also add 'ca-certificates' which is crucial for making HTTPS requests from Node.js.

--- a/public/js/modules/admin.js
+++ b/public/js/modules/admin.js
@@ -179,12 +179,17 @@ function renderLiveActivity() {
             ? `<span class="transcode-indicator bg-orange-400" title="Transcoding with FFmpeg"></span>`
             : `<span class="transcode-indicator bg-green-400" title="Direct Redirect"></span>`;
 
+        // Use image proxy for channel logos
+        const channelLogo = stream.channelLogo && stream.channelLogo.startsWith('http')
+            ? `/api/image-proxy?url=${encodeURIComponent(stream.channelLogo)}`
+            : stream.channelLogo || 'https://placehold.co/40x40/1f2937/d1d5db?text=?';
+
         tr.innerHTML = `
             <td><span class="clickable-username" title="Filter history for this user">${stream.username}</span></td>
             <td>${stream.clientIp || 'N/A'}</td>
             <td>
                 <div class="flex items-center gap-3">
-                    <img src="${stream.channelLogo || 'https://placehold.co/40x40/1f2937/d1d5db?text=?'}" 
+                    <img src="${channelLogo}" 
                          onerror="this.onerror=null; this.src='https://placehold.co/40x40/1f2937/d1d5db?text=?';" 
                          class="w-10 h-10 object-contain rounded-md bg-gray-700 flex-shrink-0" 
                          alt="Channel Logo">
@@ -232,12 +237,16 @@ function renderWatchHistory() {
 
     history.forEach(entry => {
         const tr = document.createElement('tr');
+        // Use image proxy for channel logos
+        const channelLogo = entry.channel_logo && entry.channel_logo.startsWith('http')
+            ? `/api/image-proxy?url=${encodeURIComponent(entry.channel_logo)}`
+            : entry.channel_logo || 'https://placehold.co/40x40/1f2937/d1d5db?text=?';
         tr.innerHTML = `
             <td><span class="clickable-username" title="Filter history for this user">${entry.username}</span></td>
             <td>${entry.client_ip || 'N/A'}</td>
             <td>
                 <div class="flex items-center gap-3">
-                    <img src="${entry.channel_logo || 'https://placehold.co/40x40/1f2937/d1d5db?text=?'}" 
+                    <img src="${channelLogo}" 
                          onerror="this.onerror=null; this.src='https://placehold.co/40x40/1f2937/d1d5db?text=?';" 
                          class="w-10 h-10 object-contain rounded-md bg-gray-700 flex-shrink-0" 
                          alt="Channel Logo">

--- a/public/js/modules/guide.js
+++ b/public/js/modules/guide.js
@@ -56,7 +56,10 @@ export function openProgramDetails(progItem) {
     }
 
     const channelName = channelData.displayName || channelData.name;
-    const channelLogo = channelData.logo;
+    // Use image proxy for channel logos
+    const channelLogo = channelData.logo && channelData.logo.startsWith('http')
+        ? `/api/image-proxy?url=${encodeURIComponent(channelData.logo)}`
+        : channelData.logo;
     const channelUrl = channelData.url;
 
     // Get fresh references to buttons inside the modal
@@ -513,10 +516,13 @@ const renderGuide = (channelsToRender, resetScroll = false, shouldCenter = false
                     `data-channel-id="${channel.id}" class="w-6 h-6 text-gray-500 hover:text-yellow-400 favorite-star cursor-pointer ${channel.isFavorite ? 'favorited' : ''}"`
                 );
 
+                const proxiedLogo = channel.logo && channel.logo.startsWith('http')
+                    ? `/api/image-proxy?url=${encodeURIComponent(channel.logo)}`
+                    : channel.logo;
                 const channelInfoHTML = `
                     <div class="channel-info p-2 flex items-center justify-between cursor-pointer" data-url="${channel.url}" data-name="${channelName}" data-id="${channel.id}" data-channel-index="${i}">
                         <div class="flex items-center overflow-hidden flex-grow min-w-0">
-                            <img src="${channel.logo}" onerror="this.onerror=null; this.src='https://placehold.co/48x48/1f2937/d1d5db?text=?';" class="w-12 h-12 object-contain mr-3 flex-shrink-0 rounded-md bg-gray-700">
+                            <img src="${proxiedLogo}" onerror="this.onerror=null; this.src='https://placehold.co/48x48/1f2937/d1d5db?text=?';" class="w-12 h-12 object-contain mr-3 flex-shrink-0 rounded-md bg-gray-700">
                             <div class="flex-grow min-w-0 channel-details">
                                 <span class="font-semibold text-sm truncate block">${channelName}</span>
                                 <div class="flex items-center gap-2 mt-1">
@@ -840,30 +846,40 @@ const renderSearchResults = (channelResults, programResults) => {
 
     if (channelResults.length > 0) {
         html += '<div class="search-results-header">Channels</div>';
-        html += channelResults.map(({ item }) => `
-            <div class="search-result-channel flex items-center p-3 border-b border-gray-700/50 hover:bg-gray-700 cursor-pointer" data-channel-id="${item.id}">
-                <img src="${item.logo}" onerror="this.onerror=null; this.src='https://placehold.co/40x40/1f2937/d1d5db?text=?';" class="w-10 h-10 object-contain mr-3 rounded-md bg-gray-700 flex-shrink-0">
-                <div class="overflow-hidden">
-                    <p class="font-semibold text-white text-sm truncate">${item.chno ? `[${item.chno}] ` : ''}${item.displayName || item.name}</p>
-                    <p class="text-gray-400 text-xs truncate">${item.group} &bull; ${item.source}</p>
+        html += channelResults.map(({ item }) => {
+            const proxiedLogo = item.logo && item.logo.startsWith('http')
+                ? `/api/image-proxy?url=${encodeURIComponent(item.logo)}`
+                : item.logo;
+            return `
+                <div class="search-result-channel flex items-center p-3 border-b border-gray-700/50 hover:bg-gray-700 cursor-pointer" data-channel-id="${item.id}">
+                    <img src="${proxiedLogo}" onerror="this.onerror=null; this.src='https://placehold.co/40x40/1f2937/d1d5db?text=?';" class="w-10 h-10 object-contain mr-3 rounded-md bg-gray-700 flex-shrink-0">
+                    <div class="overflow-hidden">
+                        <p class="font-semibold text-white text-sm truncate">${item.chno ? `[${item.chno}] ` : ''}${item.displayName || item.name}</p>
+                        <p class="text-gray-400 text-xs truncate">${item.group} &bull; ${item.source}</p>
+                    </div>
                 </div>
-            </div>
-        `).join('');
+            `;
+        }).join('');
     }
 
     if (programResults.length > 0) {
         html += '<div class="search-results-header">Programs</div>';
         const timeFormat = { hour: '2-digit', minute: '2-digit' };
-        html += programResults.map(({ item }) => `
-             <div class="search-result-program flex items-center p-3 border-b border-gray-700/50 hover:bg-gray-700 cursor-pointer" data-channel-id="${item.channel.id}" data-prog-start="${item.start}">
-                <img src="${item.channel.logo}" onerror="this.onerror=null; this.src='https://placehold.co/40x40/1f2937/d1d5db?text=?';" class="w-10 h-10 object-contain mr-3 rounded-md bg-gray-700 flex-shrink-0">
-                <div class="overflow-hidden">
-                    <p class="font-semibold text-white text-sm truncate" title="${item.title}">${item.title}</p>
-                    <p class="text-gray-400 text-xs truncate">${item.channel.name} &bull; ${item.channel.source}</p>
-                    <p class="text-blue-400 text-xs">${new Date(item.start).toLocaleTimeString([], timeFormat)} - ${new Date(item.stop).toLocaleTimeString([], timeFormat)}</p>
+        html += programResults.map(({ item }) => {
+            const proxiedLogo = item.channel.logo && item.channel.logo.startsWith('http')
+                ? `/api/image-proxy?url=${encodeURIComponent(item.channel.logo)}`
+                : item.channel.logo;
+            return `
+                 <div class="search-result-program flex items-center p-3 border-b border-gray-700/50 hover:bg-gray-700 cursor-pointer" data-channel-id="${item.channel.id}" data-prog-start="${item.start}">
+                    <img src="${proxiedLogo}" onerror="this.onerror=null; this.src='https://placehold.co/40x40/1f2937/d1d5db?text=?';" class="w-10 h-10 object-contain mr-3 rounded-md bg-gray-700 flex-shrink-0">
+                    <div class="overflow-hidden">
+                        <p class="font-semibold text-white text-sm truncate" title="${item.title}">${item.title}</p>
+                        <p class="text-gray-400 text-xs truncate">${item.channel.name} &bull; ${item.channel.source}</p>
+                        <p class="text-blue-400 text-xs">${new Date(item.start).toLocaleTimeString([], timeFormat)} - ${new Date(item.stop).toLocaleTimeString([], timeFormat)}</p>
+                    </div>
                 </div>
-            </div>
-        `).join('');
+            `;
+        }).join('');
     }
 
     if (html) {


### PR DESCRIPTION
Updated the admin and guide modules to always use the backend image proxy for external (http/https) channel logos and posters.

This prevents mixed content errors when the site is served over HTTPS, ensuring all images load securely.
Local or relative image paths are not proxied, so internal assets continue to load directly.

The fix applies to all places where channel logos are rendered in the admin dashboard (live activity, watch history) and the TV guide.

This makes the frontend robust for HTTPS deployments and improves compatibility with external sources.