### PR TITLE
fix: prevent mobile nav menu from closing on hover

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2260,7 +2260,7 @@
 
     <!-- Mobile Navigation Menu -->
     <div id="mobile-nav-menu"
-        class="hidden fixed inset-y-0 left-0 w-64 bg-gray-900 border-r border-gray-700 z-50 flex-col py-6 px-4 transform -translate-x-full transition-transform duration-300 ease-in-out">
+        class="hidden fixed inset-y-0 left-0 w-64 bg-gray-900 border-r border-gray-700 z-50 flex flex-col py-6 px-4 transform -translate-x-full transition-transform duration-300 ease-in-out">
         <div class="flex justify-between items-center mb-6">
             <h2 class="text-xl font-bold text-white">Navigation</h2>
             <button id="mobile-menu-close"

--- a/public/js/modules/ui.js
+++ b/public/js/modules/ui.js
@@ -330,9 +330,12 @@ export const closeMobileMenu = () => {
     if (UIElements.mobileNavMenu) {
         UIElements.mobileNavMenu.classList.add('-translate-x-full');
         UIElements.mobileNavMenu.classList.remove('translate-x-0');
-        UIElements.mobileNavMenu.addEventListener('transitionend', function handler() {
-            UIElements.mobileNavMenu.classList.add('hidden');
-            UIElements.mobileNavMenu.removeEventListener('transitionend', handler);
+        UIElements.mobileNavMenu.addEventListener('transitionend', function handler(e) {
+            // Only hide after the transform transition ends (not hover background transitions)
+            if (e.propertyName === 'transform' && e.target === UIElements.mobileNavMenu) {
+                UIElements.mobileNavMenu.classList.add('hidden');
+                UIElements.mobileNavMenu.removeEventListener('transitionend', handler);
+            }
         });
     }
     if (UIElements.mobileMenuOverlay) {


### PR DESCRIPTION
The transitionend event listener in closeMobileMenu() was firing when
hovering over menu buttons due to their hover:bg-gray-800 background
transition. This caused the menu to unexpectedly hide while the overlay
remained visible.

Changes:
- Add propertyName and target checks to transitionend handler to only
  react to the menu's transform transition, not child element transitions
- Add flex class to mobile-nav-menu for proper flexbox layout