### PR TITLE
XC sources: option to use HLS (.m3u8) for live streams

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2592,6 +2592,16 @@
                                 <input type="password" id="source-editor-xc-password"
                                     class="mt-1 block w-full bg-gray-700 border border-gray-600 rounded-md px-3 py-2 text-white focus:ring-blue-500 focus:border-blue-500">
                             </div>
+                            <div>
+                                <label for="source-editor-xc-live-format"
+                                    class="block text-sm font-medium text-gray-400">Live Stream Format</label>
+                                <select id="source-editor-xc-live-format"
+                                    class="mt-1 block w-full bg-gray-700 border border-gray-600 rounded-md px-3 py-2 text-white focus:ring-blue-500 focus:border-blue-500">
+                                    <option value="ts" selected>MPEG-TS (.ts, default)</option>
+                                    <option value="m3u8">HLS (.m3u8)</option>
+                                </select>
+                                <p class="text-xs text-gray-500 mt-1">Try HLS if live channels stop after a few seconds while VOD works.</p>
+                            </div>
                         </div>
                         <div id="source-editor-refresh-container">
                             <label for="source-editor-refresh-interval"

--- a/public/js/modules/settings.js
+++ b/public/js/modules/settings.js
@@ -1021,6 +1021,7 @@ const openSourceEditor = (sourceType, source = null) => {
                         server: UIElements.sourceEditorXcUrl.value,
                         username: UIElements.sourceEditorXcUsername.value,
                         password: UIElements.sourceEditorXcPassword.value,
+                        liveFormat: UIElements.sourceEditorXcLiveFormat.value,
                     });
                 }
                 // File sources: fetch-groups only works if file is already on server (has ID or path knewn)
@@ -1084,12 +1085,14 @@ const openSourceEditor = (sourceType, source = null) => {
                         UIElements.sourceEditorXcUrl.value = xcData.server || '';
                         UIElements.sourceEditorXcUsername.value = xcData.username || '';
                         UIElements.sourceEditorXcPassword.value = xcData.password || '';
+                        UIElements.sourceEditorXcLiveFormat.value = xcData.liveFormat === 'm3u8' ? 'm3u8' : 'ts';
                     } catch (e) {
                         console.error("Could not parse XC data for editing:", e);
                         // Clear fields if data is corrupt
                         UIElements.sourceEditorXcUrl.value = '';
                         UIElements.sourceEditorXcUsername.value = '';
                         UIElements.sourceEditorXcPassword.value = '';
+                        UIElements.sourceEditorXcLiveFormat.value = 'ts';
                     }
                 }
                 break;
@@ -1337,6 +1340,7 @@ export function setupSettingsEventListeners() {
                 server: UIElements.sourceEditorXcUrl.value,
                 username: UIElements.sourceEditorXcUsername.value,
                 password: UIElements.sourceEditorXcPassword.value,
+                liveFormat: UIElements.sourceEditorXcLiveFormat.value,
             }));
             formData.append('refreshHours', UIElements.sourceEditorRefreshInterval.value);
         }
@@ -2019,6 +2023,7 @@ export function setupSettingsEventListeners() {
                         server: UIElements.sourceEditorXcUrl.value,
                         username: UIElements.sourceEditorXcUsername.value,
                         password: UIElements.sourceEditorXcPassword.value,
+                        liveFormat: UIElements.sourceEditorXcLiveFormat.value,
                     }) : null,
                     sourceId: sourceId // <-- ADD THIS LINE
                 };
@@ -2096,6 +2101,7 @@ export function setupSettingsEventListeners() {
                         server: UIElements.sourceEditorXcUrl.value,
                         username: UIElements.sourceEditorXcUsername.value,
                         password: UIElements.sourceEditorXcPassword.value,
+                        liveFormat: UIElements.sourceEditorXcLiveFormat.value,
                     }) : null,
                     refresh: true, // Tell the backend to force refresh
                     sourceId: sourceId // Pass sourceId for cache update

--- a/server.js
+++ b/server.js
@@ -1290,6 +1290,10 @@ async function processAndMergeSources(req) {
                 }
                 const xcInfo = JSON.parse(source.xc_data);
                 const { server, username, password } = xcInfo;
+                // Live stream container: 'ts' (default, raw MPEG-TS) or 'm3u8' (HLS).
+                // Some providers close raw .ts connections after a few seconds but
+                // serve the same channel fine as HLS.
+                const liveExt = xcInfo.liveFormat === 'm3u8' ? 'm3u8' : 'ts';
 
                 if (!server || !username || !password) {
                     throw new Error("XC source is missing server, username, or password.");
@@ -1320,7 +1324,7 @@ async function processAndMergeSources(req) {
                         for (const stream of liveStreams) {
                             if (stream.stream_type === 'live') {
                                 liveStreamCount++;
-                                const streamUrl = `${server}/live/${username}/${password}/${stream.stream_id}.ts`;
+                                const streamUrl = `${server}/live/${username}/${password}/${stream.stream_id}.${liveExt}`;
 
                                 // Find category name from categories array
                                 const categoryName = Array.isArray(liveCategories)


### PR DESCRIPTION
Some Xtream providers drop raw `.ts` live connections after ~10s no matter which client hits them, while the same channel as `.m3u8` plays fine. Ran into this with my provider: every live channel died once the initial buffer was gone, VOD worked, so it took a while to figure out.

This adds a "Live Stream Format" dropdown (MPEG-TS / HLS) to the XC source editor. It's saved as `liveFormat` in `xc_data` and the live URL builder uses it for the extension. Default stays `.ts`, existing sources don't change.

Tested on top of `latest`: server starts, the dropdown shows up and round-trips through edit. The `.m3u8` builder line is running on my instance now and the channels that used to stop after ~30s play through.