### PR TITLE
Route channel logos through /api/image-proxy to fix mixed content over HTTPS

### DIFF
--- a/public/js/modules/admin.js
+++ b/public/js/modules/admin.js
@@ -9,6 +9,7 @@ import { UIElements, guideState, adminState } from './state.js';
 import { apiFetch, saveUserSetting } from './api.js';
 import { showNotification, showConfirm, openModal } from './ui.js';
 import { ICONS } from './icons.js';
+import { proxiedImageUrl } from './utils.js';
 //-- ENHANCEMENT: Import channel selector functions from multiview.js to reuse the modal.
 import { populateChannelSelector } from './multiview.js';
 
@@ -237,7 +238,7 @@ function renderWatchHistory() {
             <td>${entry.client_ip || 'N/A'}</td>
             <td>
                 <div class="flex items-center gap-3">
-                    <img src="${entry.channel_logo || 'https://placehold.co/40x40/1f2937/d1d5db?text=?'}" 
+                    <img src="${proxiedImageUrl(entry.channel_logo) || 'https://placehold.co/40x40/1f2937/d1d5db?text=?'}"
                          onerror="this.onerror=null; this.src='https://placehold.co/40x40/1f2937/d1d5db?text=?';" 
                          class="w-10 h-10 object-contain rounded-md bg-gray-700 flex-shrink-0" 
                          alt="Channel Logo">

--- a/public/js/modules/guide.js
+++ b/public/js/modules/guide.js
@@ -8,7 +8,7 @@
 
 import { appState, guideState, UIElements, dvrState } from './state.js';
 import { saveUserSetting } from './api.js';
-import { parseM3U, formatTimeWithOffset } from './utils.js';
+import { parseM3U, formatTimeWithOffset, proxiedImageUrl } from './utils.js';
 import { playChannel } from './player.js';
 import { showNotification, openModal, closeModal } from './ui.js';
 import { addOrRemoveNotification, findNotificationForProgram } from './notification.js';
@@ -516,7 +516,7 @@ const renderGuide = (channelsToRender, resetScroll = false, shouldCenter = false
                 const channelInfoHTML = `
                     <div class="channel-info p-2 flex items-center justify-between cursor-pointer" data-url="${channel.url}" data-name="${channelName}" data-id="${channel.id}" data-channel-index="${i}">
                         <div class="flex items-center overflow-hidden flex-grow min-w-0">
-                            <img src="${channel.logo}" onerror="this.onerror=null; this.src='https://placehold.co/48x48/1f2937/d1d5db?text=?';" class="w-12 h-12 object-contain mr-3 flex-shrink-0 rounded-md bg-gray-700">
+                            <img src="${proxiedImageUrl(channel.logo)}" onerror="this.onerror=null; this.src='https://placehold.co/48x48/1f2937/d1d5db?text=?';" class="w-12 h-12 object-contain mr-3 flex-shrink-0 rounded-md bg-gray-700">
                             <div class="flex-grow min-w-0 channel-details">
                                 <span class="font-semibold text-sm truncate block">${channelName}</span>
                                 <div class="flex items-center gap-2 mt-1">
@@ -842,7 +842,7 @@ const renderSearchResults = (channelResults, programResults) => {
         html += '<div class="search-results-header">Channels</div>';
         html += channelResults.map(({ item }) => `
             <div class="search-result-channel flex items-center p-3 border-b border-gray-700/50 hover:bg-gray-700 cursor-pointer" data-channel-id="${item.id}">
-                <img src="${item.logo}" onerror="this.onerror=null; this.src='https://placehold.co/40x40/1f2937/d1d5db?text=?';" class="w-10 h-10 object-contain mr-3 rounded-md bg-gray-700 flex-shrink-0">
+                <img src="${proxiedImageUrl(item.logo)}" onerror="this.onerror=null; this.src='https://placehold.co/40x40/1f2937/d1d5db?text=?';" class="w-10 h-10 object-contain mr-3 rounded-md bg-gray-700 flex-shrink-0">
                 <div class="overflow-hidden">
                     <p class="font-semibold text-white text-sm truncate">${item.chno ? `[${item.chno}] ` : ''}${item.displayName || item.name}</p>
                     <p class="text-gray-400 text-xs truncate">${item.group} &bull; ${item.source}</p>
@@ -856,7 +856,7 @@ const renderSearchResults = (channelResults, programResults) => {
         const timeFormat = { hour: '2-digit', minute: '2-digit' };
         html += programResults.map(({ item }) => `
              <div class="search-result-program flex items-center p-3 border-b border-gray-700/50 hover:bg-gray-700 cursor-pointer" data-channel-id="${item.channel.id}" data-prog-start="${item.start}">
-                <img src="${item.channel.logo}" onerror="this.onerror=null; this.src='https://placehold.co/40x40/1f2937/d1d5db?text=?';" class="w-10 h-10 object-contain mr-3 rounded-md bg-gray-700 flex-shrink-0">
+                <img src="${proxiedImageUrl(item.channel.logo)}" onerror="this.onerror=null; this.src='https://placehold.co/40x40/1f2937/d1d5db?text=?';" class="w-10 h-10 object-contain mr-3 rounded-md bg-gray-700 flex-shrink-0">
                 <div class="overflow-hidden">
                     <p class="font-semibold text-white text-sm truncate" title="${item.title}">${item.title}</p>
                     <p class="text-gray-400 text-xs truncate">${item.channel.name} &bull; ${item.channel.source}</p>

--- a/public/js/modules/multiview.js
+++ b/public/js/modules/multiview.js
@@ -8,6 +8,7 @@ import { appState, guideState, UIElements } from './state.js';
 import { apiFetch, stopStream, startRedirectStream, stopRedirectStream } from './api.js';
 import { showNotification, openModal, closeModal, showConfirm } from './ui.js';
 import { ICONS } from './icons.js';
+import { proxiedImageUrl } from './utils.js';
 
 let grid;
 const players = new Map();
@@ -886,7 +887,7 @@ export function populateChannelSelector() {
              data-name="${channel.displayName || channel.name}" 
              data-url="${channel.url}"
              data-logo="${channel.logo}">
-            <img src="${channel.logo}" onerror="this.onerror=null; this.src='https://placehold.co/40x40/1f2937/d1d5db?text=?';" class="w-10 h-10 object-contain mr-3 rounded-md bg-gray-700 flex-shrink-0">
+            <img src="${proxiedImageUrl(channel.logo)}" onerror="this.onerror=null; this.src='https://placehold.co/40x40/1f2937/d1d5db?text=?';" class="w-10 h-10 object-contain mr-3 rounded-md bg-gray-700 flex-shrink-0">
             <div class="overflow-hidden">
                 <p class="font-semibold text-white text-sm truncate">${channel.displayName || channel.name}</p>
                 <p class="text-gray-400 text-xs truncate">${channel.group || 'Uncategorized'}</p>

--- a/public/js/modules/notification.js
+++ b/public/js/modules/notification.js
@@ -9,6 +9,7 @@ import { UIElements, guideState, appState } from './state.js';
 import { handleSearchAndFilter, scrollToChannel, openProgramDetails } from './guide.js';
 import { getVapidKey, subscribeToPush, addProgramNotification, getProgramNotifications, deleteProgramNotification, unsubscribeFromPush, clearPastNotifications } from './api.js';
 import { ICONS } from './icons.js'; // MODIFIED: Import the new icon library
+import { proxiedImageUrl } from './utils.js';
 
 let isSubscribed = false;
 
@@ -261,7 +262,7 @@ export const renderNotifications = () => {
 
         return `
             <div class="flex items-center p-4 border-b border-gray-700/50 hover:bg-gray-800 transition-colors rounded-md" data-notification-id="${notif.id}">
-                <img src="${notif.channelLogo || 'https://placehold.co/48x48/1f2937/d1d5db?text=?;&font=Inter'}" onerror="this.onerror=null; this.src='https://placehold.co/48x48/1f2937/d1d5db?text=?';" class="w-12 h-12 object-contain mr-4 flex-shrink-0 rounded-md bg-gray-700">
+                <img src="${proxiedImageUrl(notif.channelLogo) || 'https://placehold.co/48x48/1f2937/d1d5db?text=?;&font=Inter'}" onerror="this.onerror=null; this.src='https://placehold.co/48x48/1f2937/d1d5db?text=?';" class="w-12 h-12 object-contain mr-4 flex-shrink-0 rounded-md bg-gray-700">
                 <div class="flex-grow">
                     <p class="font-semibold text-white text-md">${notif.programTitle || 'Untitled Program'}</p>
                     <p class="text-gray-400 text-sm">${notif.channelName || 'Unknown Channel'} • ${formattedProgramTime}</p>
@@ -320,7 +321,7 @@ export const renderPastNotifications = () => {
 
         return `
             <div class="flex items-center p-4 border-b border-gray-700/50 hover:bg-gray-800 transition-colors rounded-md opacity-70" data-notification-id="${notif.id}">
-                <img src="${notif.channelLogo || 'https://placehold.co/48x48/1f2937/d1d5db?text=?;&font=Inter'}" onerror="this.onerror=null; this.src='https://placehold.co/48x48/1f2937/d1d5db?text=?';" class="w-12 h-12 object-contain mr-4 flex-shrink-0 rounded-md bg-gray-700">
+                <img src="${proxiedImageUrl(notif.channelLogo) || 'https://placehold.co/48x48/1f2937/d1d5db?text=?;&font=Inter'}" onerror="this.onerror=null; this.src='https://placehold.co/48x48/1f2937/d1d5db?text=?';" class="w-12 h-12 object-contain mr-4 flex-shrink-0 rounded-md bg-gray-700">
                 <div class="flex-grow">
                     <p class="font-semibold text-white text-md">${notif.programTitle || 'Untitled Program'}</p>
                     <p class="text-gray-400 text-sm">${notif.channelName || 'Unknown Channel'} • ${formattedProgramTime}</p>

--- a/public/js/modules/utils.js
+++ b/public/js/modules/utils.js
@@ -4,6 +4,20 @@
  */
 
 /**
+ * Routes an external image URL through the server-side image proxy so that
+ * plain-http images (e.g. provider `tvg-logo` URLs) are not blocked as mixed
+ * content when ViniPlay is served over HTTPS behind a reverse proxy.
+ * Relative/data URLs and empty values are returned unchanged.
+ * @param {string} url - The original image URL.
+ * @returns {string} The proxied URL, or the input unchanged when no proxying is needed.
+ */
+export function proxiedImageUrl(url) {
+    return url && url.startsWith('http')
+        ? `/api/image-proxy?url=${encodeURIComponent(url)}`
+        : (url || '');
+}
+
+/**
  * Parses M3U playlist data into a structured array of channel objects.
  * @param {string} data - The raw M3U content as a string.
  * @returns {Array<object>} - An array of channel objects.

--- a/public/js/modules/vod.js
+++ b/public/js/modules/vod.js
@@ -9,6 +9,7 @@ import { openModal, closeModal, showNotification } from './ui.js';
 import { ICONS } from './icons.js';
 import { saveUserSetting, fetchVodLibrary, fetchSeriesDetails } from './api.js';
 import { playVOD } from './player.js';
+import { proxiedImageUrl } from './utils.js';
 
 // Local state for VOD page
 const vodState = {
@@ -152,7 +153,7 @@ function renderVodGrid() {
             const displayLogo = item.logo || placeholderImageUrl;
 
             // Use image proxy for both HTTP and HTTPS posters to avoid mixed content warnings
-            const proxiedLogo = displayLogo.startsWith('http') ? `/api/image-proxy?url=${encodeURIComponent(displayLogo)}` : displayLogo;
+            const proxiedLogo = proxiedImageUrl(displayLogo);
 
             return `
                 <div class="vod-item" data-id="${itemIdStr}">
@@ -190,7 +191,7 @@ async function openVodDetails(item) { // Make the function async
 
     // Use image proxy for modal posters/backdrops
     const posterUrl = item.logo || `https://placehold.co/400x600/1f2937/d1d5db?text=${encodeURIComponent(item.name)}`;
-    const proxiedPoster = posterUrl.startsWith('http') ? `/api/image-proxy?url=${encodeURIComponent(posterUrl)}` : posterUrl;
+    const proxiedPoster = proxiedImageUrl(posterUrl);
     UIElements.vodDetailsPoster.src = proxiedPoster;
     UIElements.vodDetailsBackdropImg.src = item.logo ? proxiedPoster : '';
 


### PR DESCRIPTION
## Problem

When ViniPlay is served over HTTPS (e.g. behind a reverse proxy that terminates TLS), live-channel logos fail to load and every channel shows a `?` placeholder. Provider `tvg-logo` URLs are almost always plain `http://`, and the browser blocks them as **mixed content** on an HTTPS page. VOD posters are unaffected because they already go through the server-side image proxy.

## Fix

Live-channel logos were rendered directly from the raw `tvg-logo` URL in the guide list, search results, multi-view, program notifications and the admin stream-history table. This routes them through the existing `GET /api/image-proxy` endpoint (whose own comment says it exists *"to avoid mixed content warnings"*), the same way VOD posters already work, via a shared `utils.proxiedImageUrl()` helper. The inline VOD logic is refactored to use the same helper so there is a single source of truth.

- Relative / data / empty URLs pass through unchanged.
- Chromecast metadata images (`cast.js`) are intentionally left direct, since the cast device — not the browser — fetches them, and a relative proxy URL would not resolve there.

No new endpoint or dependency; reuses the image proxy that already ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
