### PR TITLE
Apply the per-source group filter to VOD, and scope the category dropdown to the active tab

### DIFF
--- a/public/js/modules/vod.js
+++ b/public/js/modules/vod.js
@@ -52,8 +52,8 @@ export async function initVodPage() {
         showNotification('Could not load VOD library.', true);
     }
 
-    // 2. Populate the category filter dropdown
-    populateVodGroups(library.categories); // Pass fetched categories
+    // 2. Populate the category filter dropdown (for the active type tab)
+    populateVodGroups();
     UIElements.vodGroupFilter.value = 'all'; // Ensure "All Categories" is selected
 
     // 3. Set initial state of the VOD Direct Play checkbox
@@ -70,10 +70,33 @@ export async function initVodPage() {
 
 
 /**
- * Populates the "All Categories" dropdown filter.
+ * Returns the active type tab: 'all', 'movies' or 'series'.
  */
-function populateVodGroups(categories) {
+function getActiveVodTypeFilter() {
+    const activeTypeBtn = document.querySelector('.vod-type-btn.active');
+    return activeTypeBtn ? activeTypeBtn.id.replace('vod-type-', '') : 'all';
+}
+
+/**
+ * Populates the "All Categories" dropdown filter.
+ * Categories are derived from the library entries of the active type tab, so the
+ * Movies tab only offers movie categories and the Series tab only series ones.
+ * The current selection is kept when it still exists for the new type.
+ */
+function populateVodGroups() {
     const selectEl = UIElements.vodGroupFilter;
+    const typeFilter = getActiveVodTypeFilter();
+    const previousValue = selectEl.value;
+
+    const categorySet = new Set();
+    vodState.fullLibrary.forEach(item => {
+        const typeMatch = (typeFilter === 'all')
+            || (typeFilter === 'movies' && item.type === 'movie')
+            || (typeFilter === 'series' && item.type === 'series');
+        if (typeMatch && item.group) categorySet.add(item.group);
+    });
+    const categories = Array.from(categorySet).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+
     selectEl.innerHTML = ''; // Clear existing options
 
     // Always add "All Categories"
@@ -82,17 +105,17 @@ function populateVodGroups(categories) {
     allOption.textContent = 'All Categories';
     selectEl.appendChild(allOption);
 
-    // Add sorted group names
-    if (categories && Array.isArray(categories)) {
-        categories.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' })).forEach(group => {
-            const option = document.createElement('option');
-            option.value = group;
-            option.textContent = group;
-            selectEl.appendChild(option);
-        });
-    }
+    categories.forEach(group => {
+        const option = document.createElement('option');
+        option.value = group;
+        option.textContent = group;
+        selectEl.appendChild(option);
+    });
 
-    console.log(`[VOD] Populated group filter with ${categories ? categories.length : 0} categories.`);
+    // Keep the previous choice if it still applies, otherwise fall back to "All"
+    selectEl.value = (previousValue && categorySet.has(previousValue)) ? previousValue : 'all';
+
+    console.log(`[VOD] Populated group filter with ${categories.length} categories for type "${typeFilter}".`);
 }
 
 /**
@@ -104,8 +127,7 @@ function renderVodGrid() {
     if (!gridEl || !noResultsEl) return;
 
     // 1. Get current filter values
-    const activeTypeBtn = document.querySelector('.vod-type-btn.active');
-    const typeFilter = activeTypeBtn ? activeTypeBtn.id.replace('vod-type-', '') : 'all'; // 'all', 'movies', 'series'
+    const typeFilter = getActiveVodTypeFilter(); // 'all', 'movies', 'series'
     const groupFilter = UIElements.vodGroupFilter.value; // 'all' or specific group
     const searchFilter = UIElements.vodSearchInput.value.toLowerCase();
 
@@ -323,18 +345,25 @@ function setupVodEventListeners() {
         UIElements.vodTypeAll.classList.add('active');
         UIElements.vodTypeMovies.classList.remove('active');
         UIElements.vodTypeSeries.classList.remove('active');
+        // Categories depend on the type tab, so rebuild the dropdown first
+        populateVodGroups();
+        vodState.pagination.currentPage = 1;
         renderVodGrid();
     });
     UIElements.vodTypeMovies.addEventListener('click', () => {
         UIElements.vodTypeAll.classList.remove('active');
         UIElements.vodTypeMovies.classList.add('active');
         UIElements.vodTypeSeries.classList.remove('active');
+        populateVodGroups();
+        vodState.pagination.currentPage = 1;
         renderVodGrid();
     });
     UIElements.vodTypeSeries.addEventListener('click', () => {
         UIElements.vodTypeAll.classList.remove('active');
         UIElements.vodTypeMovies.classList.remove('active');
         UIElements.vodTypeSeries.classList.add('active');
+        populateVodGroups();
+        vodState.pagination.currentPage = 1;
         renderVodGrid();
     });
 

--- a/server.js
+++ b/server.js
@@ -2206,7 +2206,11 @@ app.get('/api/vod/library', requireAuth, async (req, res) => {
                 providerMap.set(p.id, {
                     baseUrl: `${url.protocol}//${url.host}`,
                     username: xcInfo.username,
-                    password: xcInfo.password
+                    password: xcInfo.password,
+                    // Source-level group filter, the same selection the live M3U parser uses.
+                    // Applied here as well as at import time, so content already in the DB
+                    // from before the filter was set is hidden without needing a refresh.
+                    selectedGroups: new Set(Array.isArray(p.selectedGroups) ? p.selectedGroups : [])
                 });
             } catch (e) {
                 console.error(`[API_VOD] Skipping provider ${p.name}, invalid XC data: ${e.message}`);
@@ -2233,6 +2237,11 @@ app.get('/api/vod/library', requireAuth, async (req, res) => {
         const processedMovies = movies.map(m => {
             const provider = providerMap.get(m.provider_id);
             if (!provider) return null; // Skip if provider is not active
+
+            // SOURCE GROUP FILTER: skip categories the source's own selection excludes
+            if (provider.selectedGroups.size > 0 && !provider.selectedGroups.has(m.category_name)) {
+                return null;
+            }
 
             // PERMISSION CHECK: Filter by category if strict groups are defined
             if (allowedSources) {
@@ -2277,6 +2286,13 @@ app.get('/api/vod/library', requireAuth, async (req, res) => {
 
         // Process series headers with permission checks
         const processedSeries = seriesList.map(series => {
+            // SOURCE GROUP FILTER: skip categories the source's own selection excludes
+            const seriesProvider = providerMap.get(series.provider_id);
+            if (!seriesProvider) return null;
+            if (seriesProvider.selectedGroups.size > 0 && !seriesProvider.selectedGroups.has(series.category_name)) {
+                return null;
+            }
+
             // PERMISSION CHECK: Filter by category if strict groups are defined
             if (allowedSources) {
                 const perms = allowedSources[series.provider_id];
@@ -2523,7 +2539,17 @@ app.get('/api/vod/categories', requireAuth, async (req, res) => {
     console.log('[API_VOD] Request received for /api/vod/categories');
     try {
         const categories = await dbAll(db, "SELECT category_name FROM vod_categories ORDER BY category_name");
-        const categoryNames = categories.map(cat => cat.category_name);
+        let categoryNames = categories.map(cat => cat.category_name);
+
+        // Hide categories excluded by every active source's own group selection.
+        // vod_categories is not per-provider, so a category is kept when at least one
+        // active source either has no filter or lists it.
+        const activeSources = getSettings().m3uSources.filter(s => s.isActive);
+        if (activeSources.length > 0 && activeSources.every(s => Array.isArray(s.selectedGroups) && s.selectedGroups.length > 0)) {
+            const allowed = new Set(activeSources.flatMap(s => s.selectedGroups));
+            categoryNames = categoryNames.filter(name => allowed.has(name));
+        }
+
         res.json({ success: true, categories: categoryNames });
     } catch (error) {
         console.error(`[API_VOD] Error fetching VOD categories: ${error.message}`, error);

--- a/vodProcessor.js
+++ b/vodProcessor.js
@@ -32,6 +32,18 @@ async function refreshVodContent(db, dbGet, dbAll, dbRun, provider, sendStatus =
     const client = new XtreamClient(server_url, username, password, userAgent);
     const providerId = provider.id;
 
+    // --- Group Filter Logic ---
+    // Same source-level filter the live M3U parser applies: when the user has picked
+    // groups for this source, only import VOD whose category is in that selection.
+    const selectedGroups = Array.isArray(provider.selectedGroups) ? provider.selectedGroups : [];
+    const selectedGroupSet = new Set(selectedGroups);
+    const isGroupFilteringActive = selectedGroupSet.size > 0;
+    if (isGroupFilteringActive) {
+        console.log(`[VOD Processor] Group filter active for ${provider.name}: ${selectedGroupSet.size} groups selected.`);
+        sendStatus(` -> Applying VOD group filter. ${selectedGroupSet.size} groups selected.`, 'info');
+    }
+    // ---
+
     // --- Schema Migration ---
     try {
         await dbRun(db, "ALTER TABLE movies ADD COLUMN provider_unique_id TEXT");
@@ -122,6 +134,9 @@ async function refreshVodContent(db, dbGet, dbAll, dbRun, provider, sendStatus =
                 }
                 const categoryName = categoryMap.get(String(category_id)) || 'VOD';
 
+                // Skip movies whose category is not in the source's group selection.
+                if (isGroupFilteringActive && !selectedGroupSet.has(categoryName)) continue;
+
                 let movieId = providerUniqueIdMap.get(providerUniqueId);
 
                 if (movieId) {
@@ -182,6 +197,9 @@ async function refreshVodContent(db, dbGet, dbAll, dbRun, provider, sendStatus =
                     if (yearMatch) year = parseInt(yearMatch[1]);
                 }
                 const categoryName = categoryMap.get(String(category_id)) || 'Series';
+
+                // Skip series whose category is not in the source's group selection.
+                if (isGroupFilteringActive && !selectedGroupSet.has(categoryName)) continue;
 
                 let seriesId = providerUniqueIdMap.get(providerUniqueId);
 
@@ -261,6 +279,12 @@ async function processM3uVod(db, dbGet, dbAll, dbRun, m3uContent, provider, send
     const scanStartTime = new Date().toISOString();
     const providerId = provider.id;
 
+    // --- Group Filter Logic (same selection as the live M3U parser uses) ---
+    const selectedGroups = Array.isArray(provider.selectedGroups) ? provider.selectedGroups : [];
+    const selectedGroupSet = new Set(selectedGroups);
+    const isGroupFilteringActive = selectedGroupSet.size > 0;
+    // ---
+
     try {
         const lines = m3uContent.split('\n');
         let currentExtInf = null;
@@ -283,6 +307,13 @@ async function processM3uVod(db, dbGet, dbAll, dbRun, m3uContent, provider, send
                 const url = line.trim();
                 const isMovie = url.includes('/movie/') || currentExtInf.attributes['tvg-type'] === 'movie';
                 const isSeries = url.includes('/series/') || currentExtInf.attributes['tvg-type'] === 'series';
+
+                // Skip entries whose group is not in the source's group selection.
+                const groupTitle = currentExtInf.attributes['group-title'] || (isSeries ? 'Series' : 'VOD');
+                if (isGroupFilteringActive && !selectedGroupSet.has(groupTitle)) {
+                    currentExtInf = null;
+                    continue;
+                }
 
                 if (isMovie) {
                     movies.push({ ...currentExtInf, url });


### PR DESCRIPTION
## Problem

Selecting groups on an M3U source (*Settings → source → Select Groups*) only filters **live channels**. The check lives in the live-M3U parse loop in `server.js`; nothing in the VOD path looks at `source.selectedGroups`, so:

- `vodProcessor.js` imports every category the provider offers, regardless of the selection.
- `/api/vod/library` returns all of it. The only group filter it applies is the unrelated **per-user** one (`users.allowed_sources`), which is empty unless per-user permissions have been configured.

On my provider, a source with 38 groups selected still produced **224 movie categories / 106k movies** and **144 series categories / 27k series** in the database, all of them listed on the VODs page. The *Select Groups for VOD* tabs in the source editor therefore appear to do nothing.

A second, smaller issue on the same page: the category dropdown is built once from every category in the library, so the **Movies** tab offers series categories and the **Series** tab offers movie categories.

## Changes

**1. Honour `source.selectedGroups` for VOD** (`vodProcessor.js`, `server.js`)

- At import: `refreshVodContent` (Xtream movies + series) and `processM3uVod` (plain-M3U VOD) skip entries whose category is not in the source's selection. The existing stale-relation cleanup at the end of a refresh then removes anything imported before the filter was set, so the library converges on its own.
- At read: `/api/vod/library` applies the same filter, so a newly set selection takes effect immediately instead of only after the next source refresh. `/api/vod/categories` got the same treatment for consistency (the frontend doesn't call it — the VODs dropdown is derived from the library response).

An empty selection keeps the current behaviour: everything is imported and shown.

**2. Scope the category dropdown to the active type tab** (`public/js/modules/vod.js`)

Categories are now derived from the library entries matching the active tab and rebuilt when the tab changes. The current pick is kept when it still exists for the new type, otherwise it falls back to *All Categories* (rather than leaving a selection that matches nothing). Switching tabs also resets to page 1, which previously could land you on an empty page.

## Testing

Running live on a Synology Docker deployment against an Xtream provider, `0.11.0` plus these changes. After one source refresh the database went from 224 movie categories / 106,149 movies and 144 series categories / 26,747 series to **20 / 15,833** and **19 / 4,600** — every remaining category inside the 38-group selection, and the two categories that legitimately carry both movies and series still present in both tabs. Sources with no group selection were unaffected.

## Note on shared selections

The source editor's Live / VOD-Movies / VOD-Series tabs write into a single `selectedGroups` array per source. With this change, a source where only live groups are ticked will import no VOD at all. That matches the intent of the setting as I read it, but it is a behaviour change for anyone who set a live-only selection and relied on VOD coming through unfiltered — worth a mention in release notes if you take this.