### PR TITLE
Fix non-unique channel IDs for empty tvg-id=""

### DIFF
--- a/server.js
+++ b/server.js
@@ -1414,7 +1414,11 @@ async function processAndMergeSources(req) {
                     const name = nameMatch ? nameMatch[1] : ((commaIndex !== -1) ? currentExtInf.substring(commaIndex + 1).trim() : 'Unknown');
 
                     // Consistent Unique Channel ID Generation
-                    const originalTvgId = idMatch ? idMatch[1] : `no-tvg-id-${name.replace(/[^a-zA-Z0-9]/g, '')}`;
+                    // Treat an empty tvg-id="" the same as a missing attribute: otherwise
+                    // every channel with an empty tvg-id collapses to the same generated ID
+                    // (src-<sourceId>_), which breaks favorites and recents (they key on this
+                    // ID). idMatch is truthy for tvg-id="", so guard on the captured value.
+                    const originalTvgId = (idMatch && idMatch[1]) ? idMatch[1] : `no-tvg-id-${name.replace(/[^a-zA-Z0-9]/g, '')}`;
                     const finalUniqueChannelId = `${source.id}_${originalTvgId}`;
 
                     // Inject the *corrected* unique ID into the #EXTINF line


### PR DESCRIPTION
## Problem

Live M3U channels whose `#EXTINF` carries an **empty** `tvg-id=""` all collapse to the **same** generated channel ID, `src-<sourceId>_`.

The unique-ID builder falls back to a name-based ID only when the `tvg-id` attribute is *absent*:

```js
const originalTvgId = idMatch ? idMatch[1] : `no-tvg-id-${name.replace(/[^a-zA-Z0-9]/g, '')}`;
```

But `idMatch` is truthy for `tvg-id=""` (the regex `tvg-id="([^"]*)"` matches, capturing `""`), so `originalTvgId` becomes `""` and every empty-tvg-id channel gets the identical ID `<sourceId>_`.

## Impact

Favorites and "recently watched" both key on this channel ID, so all empty-tvg-id channels become indistinguishable. Toggling a star on one saves a single ambiguous ID (`["src-…_"]`) that matches none of them on reload, so favorites and recents silently fail to persist.

On one real provider playlist this affected **1821 channels** collapsing onto a single ID.

## Fix

Guard the fallback on the captured value, so an empty `tvg-id` is treated the same as a missing one and each channel gets a unique name-based ID:

```js
const originalTvgId = (idMatch && idMatch[1]) ? idMatch[1] : `no-tvg-id-${name.replace(/[^a-zA-Z0-9]/g, '')}`;
```

The existing `if (idMatch)` injection branch below is unaffected — it still rewrites the empty `tvg-id=""` attribute in place with the new unique ID.

## Testing

Applied against the same 1821-channel playlist and refreshed the source: the collapsed IDs dropped from 1821-sharing-one to 0, with 1787 unique name-based IDs. Favorites and recents now persist correctly. (The small remainder are genuinely duplicate-named channels — the same limitation the pre-existing name-based fallback already has.)
